### PR TITLE
update phantom js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - '0.10'
+  - '0.12'

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ var gutil = require('gulp-util')
 var _ = require('lodash')
 var phridge = require('phridge')
 var fs = require('fs')
-var when = require('when')
 
 var SPRITE_TEMPLATE = path.join(__dirname, 'templates', 'sprite.html')
 
@@ -55,7 +54,6 @@ module.exports = function (options) {
       })
       .then(generateSprite)
       .then(function (sprite) {
-
         self.push(new gutil.File({
           path: fileName + '.png'
         , contents: new Buffer(sprite.img, 'base64')
@@ -67,7 +65,7 @@ module.exports = function (options) {
         })
 
       })
-      .done(
+      .then(
         function (css) {
           self.push(new gutil.File({
             path: fileName + '.css'
@@ -88,7 +86,7 @@ module.exports = function (options) {
 
 
 function renderTemplate (fileName, options) {
-  return when.promise(function (resolve, reject) {
+  return new Promise(function (resolve, reject) {
     fs.readFile(fileName, function (err, template) {
       if (err) return reject(err)
       try {
@@ -106,7 +104,10 @@ function generateSprite (opts) {
     .then(function (phantom) {
       return phantom
         .run(opts, phantomScript)
-        .finally(phantom.dispose.bind(phantom))
+            .then((res) => {
+                phantom.dispose.bind(phantom)
+                return res;
+            }, phantom.dispose.bind(phantom))
     })
 }
 

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ function generateSprite (opts) {
     .then(function (phantom) {
       return phantom
         .run(opts, phantomScript)
-            .then((res) => {
+            .then(function (res) {
                 phantom.dispose.bind(phantom)
                 return res;
             }, phantom.dispose.bind(phantom))

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   "dependencies": {
     "gulp-util": "^3.0.1",
     "lodash": "^3.9.1",
-    "phridge": "^1.1.0",
-    "when": "^3.7.3"
+    "phridge": "^2.0.0"
   },
   "devDependencies": {
     "gulp": "^3.8.10",


### PR DESCRIPTION
PhantomJS 1.9.x is broken under macOS sierra and won't be fixed (https://github.com/ariya/phantomjs/issues/14558)

Therefore this needs to be updated to work with sierra. This PR updates phridge to the latest version, removes when and does all the necessary compatibility changes to make it work. Tests pass locally on my macOS sierra.
